### PR TITLE
allow commas in cells using `\,`

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,7 +56,9 @@ export default function App() {
 
   const appendRow = useCallback(
     (rowString: string) => {
-      const row = rowString.split(",");
+      const row = rowString
+        .split(/[^\\],/)
+        .map((cell) => cell.replaceAll("\\,", ","));
       console.log(row);
 
       gapi.client.sheets.spreadsheets.values


### PR DESCRIPTION
Before and after, entering `cheese\, biscuits\, crackers`:

![Screenshot from 2022-06-17 12-04-46](https://user-images.githubusercontent.com/292958/174286513-44ca2ed5-aa2c-4d81-9d57-8ca5547da689.png)

