### PR TITLE
Refresh Google access token 30s before timeout

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-  "editor.formatOnSave": true
+  "editor.formatOnSave": true,
+  "cSpell.words": [
+    "gapi"
+  ]
 }

--- a/src/getAccessTokenFromServiceAccount.ts
+++ b/src/getAccessTokenFromServiceAccount.ts
@@ -1,6 +1,3 @@
-// This is a Javascript library to retrieve the access token from the Google Service Account.
-// Adapted from  https://github.com/tanaikech/GetAccessTokenFromServiceAccount_js
-
 import { JSEncrypt } from "jsencrypt";
 import CryptoJS from "crypto-js";
 
@@ -14,9 +11,19 @@ export interface ServiceAccountJson {
   client_email: string;
 }
 
+export interface GoogleApiAccessToken {
+  access_token: string;
+  expires_in: number;
+  token_type: "Bearer";
+}
+
+/**
+ * Retrieve the access token from the Google Service Account.
+ * Adapted from  https://github.com/tanaikech/GetAccessTokenFromServiceAccount_js
+ */
 export default async function getAccessTokenFromServiceAccount(
   serviceAccountJson: ServiceAccountJson
-) {
+): Promise<GoogleApiAccessToken> {
   const { private_key, client_email, scopes } = serviceAccountJson;
   if (!private_key || !client_email || !scopes) {
     throw new Error(

--- a/src/googleApi.ts
+++ b/src/googleApi.ts
@@ -1,0 +1,83 @@
+import { useCallback, useEffect, useState } from "react";
+import getAccessTokenFromServiceAccount, {
+  GoogleApiAccessToken,
+  ServiceAccountJson,
+} from "./getAccessTokenFromServiceAccount";
+
+function useGoogleApiAccessToken(
+  scopes: string[],
+  serviceAccount: ServiceAccountJson | undefined,
+  earlyTokenRefresh_seconds = 30
+): GoogleApiAccessToken | undefined {
+  const [accessToken, setAccessToken] = useState<GoogleApiAccessToken>();
+
+  const getAccessToken = useCallback(() => {
+    if (serviceAccount) {
+      const serviceAccountWithScopes = { ...serviceAccount, scopes };
+
+      let refreshAccessTokenTimeout: NodeJS.Timeout | null;
+
+      getAccessTokenFromServiceAccount(serviceAccountWithScopes).then(
+        (newAccessToken) => {
+          setAccessToken(newAccessToken);
+          refreshAccessTokenTimeout = setTimeout(
+            getAccessToken,
+            (newAccessToken.expires_in - earlyTokenRefresh_seconds) * 1000
+          );
+        }
+      );
+
+      return () => {
+        if (refreshAccessTokenTimeout) {
+          clearTimeout(refreshAccessTokenTimeout);
+        }
+      };
+    }
+  }, [serviceAccount, scopes, earlyTokenRefresh_seconds]);
+
+  useEffect(() => {
+    const cancel = getAccessToken();
+    return cancel;
+  }, [getAccessToken]);
+
+  return accessToken;
+}
+
+function useGoogleApiUnauthenticated(discoveryDocs: string[]) {
+  const [googleApi, setGoogleApi] = useState<typeof gapi>();
+
+  useEffect(() => {
+    gapi.load("client", () => {
+      gapi.client.init({ discoveryDocs }).then(() => {
+        setGoogleApi(gapi);
+      });
+    });
+  }, [discoveryDocs]);
+
+  return googleApi;
+}
+
+export default function useGoogleApi(options: {
+  scopes: string[];
+  discoveryDocs: string[];
+  serviceAccount: ServiceAccountJson;
+  earlyTokenRefresh_seconds?: number;
+}) {
+  const googleApi = useGoogleApiUnauthenticated(options.discoveryDocs);
+  const accessToken = useGoogleApiAccessToken(
+    options.scopes,
+    options.serviceAccount,
+    options.earlyTokenRefresh_seconds
+  );
+
+  useEffect(() => {
+    if (googleApi && accessToken) {
+      // Types don't quite match up bit it works
+      googleApi.auth.setToken(
+        accessToken as unknown as GoogleApiOAuth2TokenObject
+      );
+    }
+  }, [accessToken, googleApi]);
+
+  return googleApi && accessToken ? googleApi : undefined;
+}


### PR DESCRIPTION
Looks at the `expires_in` in the access token and fetches a new access token 30 seconds before.